### PR TITLE
Update to API 51 and Test Class Fixes

### DIFF
--- a/src/classes/CalculateBusinessHoursAgesTest.cls
+++ b/src/classes/CalculateBusinessHoursAgesTest.cls
@@ -1,5 +1,7 @@
-public class CalculateBusinessHoursAgesTest {
-    public static testMethod void testBusinessHoursBucketer() {
+@istest
+private class CalculateBusinessHoursAgesTest {
+    	@istest
+	private static void CalculateBusinessHoursAgesTest() {
         Stop_Status__c ss = new Stop_Status__c(Name = 'On Hold');
         insert ss;
 
@@ -14,8 +16,8 @@ public class CalculateBusinessHoursAgesTest {
         c.Status = 'New';
         update c;
 
-		Case updatedCase = [select Time_With_Customer__c,Time_With_Support__c,Case_Age_In_Business_Hours__c from Case where Id=:c.Id];
-		System.assert(updatedCase.Time_With_Customer__c!=null);
+	Case updatedCase = [select Time_With_Customer__c,Time_With_Support__c,Case_Age_In_Business_Hours__c from Case where Id=:c.Id];
+	System.assert(updatedCase.Time_With_Customer__c!=null);
         System.assert(updatedCase.Time_With_Support__c!=null);
         System.assert(updatedCase.Case_Age_In_Business_Hours__c==null);
 

--- a/src/classes/CalculateBusinessHoursAgesTest.cls-meta.xml
+++ b/src/classes/CalculateBusinessHoursAgesTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>13.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/triggers/CalculateBusinessHoursAges.trigger-meta.xml
+++ b/src/triggers/CalculateBusinessHoursAges.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>13.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>


### PR DESCRIPTION
Udpated to API 51 and the isTest methods are now used correctly. Test classes made private. 
SF Test Response: CalculateBusinessHoursAgesTest.CalculateBusinessHoursAgesTest  CalculateBusinessHoursAges = Pass 100% 